### PR TITLE
examples/producer: Rethrow Auth{Z,N} errors

### DIFF
--- a/examples/producer/src/main/java/io/strimzi/examples/producer/ExampleProducer.java
+++ b/examples/producer/src/main/java/io/strimzi/examples/producer/ExampleProducer.java
@@ -90,8 +90,7 @@ public class ExampleProducer {
             } catch (ExecutionException e) {
                 if (e.getCause() instanceof AuthenticationException
                         || e.getCause() instanceof AuthorizationException) {
-                    producer.close();
-                    producer = new KafkaProducer<>(props);
+                    throw e;
                 } else {
                     throw new RuntimeException("Failed to send message: " + i, e);
                 }


### PR DESCRIPTION
Instead of carrying on