### PR TITLE
examples/producer: `throws` annotation on main()

### DIFF
--- a/examples/producer/src/main/java/io/strimzi/examples/producer/ExampleProducer.java
+++ b/examples/producer/src/main/java/io/strimzi/examples/producer/ExampleProducer.java
@@ -30,7 +30,7 @@ public class ExampleProducer {
      *
      * @param args No arguments expected
      */
-    public static void main(String[] args) {
+    public static void main(String[] args) throws ExecutionException {
 
         String topic = args[0];
         Integer numRecords = Integer.parseInt(args[1]);


### PR DESCRIPTION
Otherwise mvn complains