### PR TITLE
producer: Wrap ExecutionException in a RuntimeException to silence doclint

### DIFF
--- a/examples/producer/src/main/java/io/strimzi/examples/producer/ExampleProducer.java
+++ b/examples/producer/src/main/java/io/strimzi/examples/producer/ExampleProducer.java
@@ -30,7 +30,7 @@ public class ExampleProducer {
      *
      * @param args No arguments expected
      */
-    public static void main(String[] args) throws ExecutionException {
+    public static void main(String[] args) {
 
         String topic = args[0];
         Integer numRecords = Integer.parseInt(args[1]);
@@ -90,7 +90,7 @@ public class ExampleProducer {
             } catch (ExecutionException e) {
                 if (e.getCause() instanceof AuthenticationException
                         || e.getCause() instanceof AuthorizationException) {
-                    throw e;
+                    throw new RuntimeException(e);
                 } else {
                     throw new RuntimeException("Failed to send message: " + i, e);
                 }


### PR DESCRIPTION
What it says on the box. After upgrading ducktape containers to openjdk-17, the javadoc linter was complaining that there was no "@throw of concurrent.ExecutionException" in the function. It was wrong, but wrapping the raw error in a `RuntimeException` silenced the linter w/o breaking our usage. Tests still pass.

See https://github.com/redpanda-data/redpanda/pull/15951